### PR TITLE
Feature/Global overrides for multiple managers + Refactoring

### DIFF
--- a/pyinject/_dependency.py
+++ b/pyinject/_dependency.py
@@ -15,16 +15,19 @@ class _Dependency:
         Validates that the given value is a _Dependency object
 
         Args:
+        ----
             _value (object): A value to validate
 
         Raises:
+        ------
             ValueError: If the given value is not a _Dependency object
+
         """
         if not isinstance(_value, _Dependency):
-            raise ValueError(
+            raise TypeError(
                 "Dependency must be a _Dependency object,\n"
                 "please use the Depends() function to define a dependency.\n"
                 "Examples:\n"
                 "1. Annotated[MyDependency, Depends()] \n"
-                "2. Annotated[MyDependency, Depends(get_my_dependency)]"
+                "2. Annotated[MyDependency, Depends(get_my_dependency)]",
             )

--- a/pyinject/decorators.py
+++ b/pyinject/decorators.py
@@ -62,7 +62,7 @@ class _AutoWired:
         new_kwargs = original_kwargs.copy()
 
         for param_name, param in sig.parameters.items():
-            if param_name in bound_args.arguments:
+            if param_name in bound_args.arguments or param.annotation is inspect.Parameter.empty:
                 continue
 
             # Case of Annotated[<type>, Dependency(...)]
@@ -73,7 +73,7 @@ class _AutoWired:
                 new_kwargs[param_name] = self.manager.get_dependency_value(_dependency)
 
             # Case of globally overridden dependency without Annotated[<type>, Dependency(...)]
-            elif param.annotation is not inspect.Parameter.empty and param.annotation in self.manager.dependency_overrides:
+            elif param.annotation in self.manager.dependency_overrides:
                 _dependency = _Dependency(callable=param.annotation, cache=False)
                 new_kwargs[param_name] = self.manager.get_dependency_value(_dependency)
 

--- a/pyinject/decorators.py
+++ b/pyinject/decorators.py
@@ -9,15 +9,18 @@ R = TypeVar("R", bound=Any)
 P = ParamSpec("P")
 
 
-def AutoWired(*, manager: DependenciesManager = default_manager) -> Callable[[Callable[P, R]], Callable[P, R]]:
+def AutoWired(*, manager: DependenciesManager = default_manager) -> Callable[[Callable[P, R]], Callable[P, R]]:  # noqa: N802
     """
     A decorator that resolves dependencies from a callable and injects them to arguments Annotations
 
     Args:
+    ----
         manager (DependenciesManager, optional): A manager that holds the dependencies. Defaults to default_manager.
 
     Returns:
+    -------
         Callable[[Callable[P, R]], Callable[P, R]]: A decorator that resolves dependencies
+
     """
 
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
@@ -39,6 +42,10 @@ def AutoWired(*, manager: DependenciesManager = default_manager) -> Callable[[Ca
                         _dependency.callable = _type
 
                     kwargs[param_name] = manager.get_dependency_value(_dependency)
+                    continue
+
+                if param.annotation is not None and param.annotation in manager.dependency_overrides:
+                    kwargs[param_name] = manager.get_dependency_value(_Dependency(callable=param.annotation))
 
             return func(*args, **kwargs)
 

--- a/pyinject/decorators.py
+++ b/pyinject/decorators.py
@@ -9,6 +9,78 @@ R = TypeVar("R", bound=Any)
 P = ParamSpec("P")
 
 
+class _AutoWired:
+    """A class that resolves dependencies from a callable and injects them to arguments Annotations"""
+
+    def __init__(self, manager: DependenciesManager) -> None:
+        self.manager = manager
+
+    def __call__(self, func: Callable[P, R]) -> Callable[P, R]:
+        """Decorator that resolves dependencies from a callable and injects them to arguments Annotations.
+
+        Args:
+        ----
+            func (Callable[P, R]): A callable to be decorated
+
+        Returns:
+        -------
+            Callable[P, R]: A decorated callable
+
+        """
+        sig = inspect.signature(func)
+
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            bound_args = sig.bind_partial(*args, **kwargs)
+            bound_args.apply_defaults()
+
+            kwargs_after_injection = self._inject_dependencies_to_kwargs(bound_args, sig, kwargs)
+
+            return func(*args, **kwargs_after_injection)
+
+        return wrapper
+
+    def _inject_dependencies_to_kwargs(
+        self,
+        bound_args: inspect.BoundArguments,
+        sig: inspect.Signature,
+        original_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Injects dependencies to the arguments Annotations.
+
+        Args:
+        ----
+            bound_args (inspect.BoundArguments): A bound arguments object
+            sig (inspect.Signature): A signature object
+            kwargs (dict[str, Any]): A dictionary containing the keyword arguments
+
+        Returns:
+        -------
+            dict[str, Any]: A dictionary containing the keyword arguments after injection
+
+        """
+        new_kwargs = original_kwargs.copy()
+
+        for param_name, param in sig.parameters.items():
+            if param_name in bound_args.arguments:
+                continue
+
+            if get_origin(param.annotation) is Annotated:
+                _type, _dependency = get_args(param.annotation)
+                _Dependency.validate(_dependency)
+
+                if _dependency.callable is None:
+                    _dependency.callable = _type
+
+                new_kwargs[param_name] = self.manager.get_dependency_value(_dependency)
+                continue
+
+            if param.annotation in self.manager.dependency_overrides:
+                new_kwargs[param_name] = self.manager.get_dependency_value(_Dependency(callable=param.annotation))
+
+        return new_kwargs
+
+
 def AutoWired(*, manager: DependenciesManager = default_manager) -> Callable[[Callable[P, R]], Callable[P, R]]:  # noqa: N802
     """
     A decorator that resolves dependencies from a callable and injects them to arguments Annotations
@@ -22,33 +94,4 @@ def AutoWired(*, manager: DependenciesManager = default_manager) -> Callable[[Ca
         Callable[[Callable[P, R]], Callable[P, R]]: A decorator that resolves dependencies
 
     """
-
-    def decorator(func: Callable[P, R]) -> Callable[P, R]:
-        @wraps(func)
-        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            sig = inspect.signature(func)
-            bound_args = sig.bind_partial(*args, **kwargs)
-            bound_args.apply_defaults()
-
-            for param_name, param in sig.parameters.items():
-                if param_name in bound_args.arguments:
-                    continue
-
-                if get_origin(param.annotation) is Annotated:
-                    _type, _dependency = get_args(param.annotation)
-                    _Dependency.validate(_dependency)
-
-                    if _dependency.callable is None:
-                        _dependency.callable = _type
-
-                    kwargs[param_name] = manager.get_dependency_value(_dependency)
-                    continue
-
-                if param.annotation is not None and param.annotation in manager.dependency_overrides:
-                    kwargs[param_name] = manager.get_dependency_value(_Dependency(callable=param.annotation))
-
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
+    return _AutoWired(manager=manager)

--- a/pyinject/functions.py
+++ b/pyinject/functions.py
@@ -6,29 +6,61 @@ from .manager import DependenciesManager
 R = TypeVar("R", bound=Any)
 
 
-def Depends(callable: Callable[..., Any] | None = None, cache: bool = True) -> _Dependency:
+def Depends(_callable: Callable[..., Any] | None = None, cache: bool = True) -> _Dependency:  # noqa: N802, FBT002
     """
     Given a callable, returns a Dependency object that can be used to annotate
 
     Args:
+    ----
         callable (Callable[..., Any]): A callable that returns a dependency
         cache (bool, optional): Whether or not to cache the dependency. Defaults to True.
 
     Returns:
+    -------
         _Dependency: A dependency object that can be used to annotate
+
     """
-    return _Dependency(callable, cache)
+    return _Dependency(_callable, cache)
 
 
 def get_default_manager() -> DependenciesManager:
+    """
+    Returns the default DependenciesManager instance.
+
+    Returns
+    -------
+        DependenciesManager: The default DependenciesManager instance.
+
+    """
     from .manager import default_manager
 
     return default_manager
 
 
 def create_manager() -> DependenciesManager:
+    """
+    Returns a new DependenciesManager instance.
+
+    Returns
+    -------
+        DependenciesManager: A new DependenciesManager instance.
+
+    """
     return DependenciesManager()
 
 
 def execute(starting_point: Callable[..., R], *args: Any, **kwargs: Any) -> R:
+    """Executes a function with the given arguments and keyword arguments
+
+    Args:
+    ----
+        starting_point (Callable[..., R]): The function to execute
+        *args (Any): The positional arguments
+        **kwargs (Any): The keyword arguments
+
+    Returns:
+    -------
+        R: The result of the function
+
+    """
     return starting_point(*args, **kwargs)

--- a/pyinject/manager.py
+++ b/pyinject/manager.py
@@ -7,11 +7,7 @@ OverridesMapping = dict[Callable[..., Any], Callable[..., Any]]
 
 
 class DependenciesManager:
-    """
-    A class that manages dependencies and their caching
-
-    uses a singleton metaclass to ensure only one instance of this class exists
-    """
+    """A class that manages dependencies and their caching."""
 
     __slots__ = ["cached_dependencies_values", "_caching_lock", "_overrides_lock", "dependency_overrides"]
 
@@ -26,12 +22,14 @@ class DependenciesManager:
         Given a _Dependency object, returns the dependency value, caching it if needed
 
         Args:
+        ----
             _dependency (_Dependency): A _Dependency object
 
         Returns:
+        -------
             Any: The dependency value
-        """
 
+        """
         if _dependency.callable is None:
             raise ValueError("Dependency cannot be None, please provide a callable")
 
@@ -56,13 +54,14 @@ class DependenciesManager:
         Overrides the dependencies with the provided overrides.
 
         Args:
+        ----
             overrides (OverridesMapping): A dictionary containing the dependencies to be overridden.
 
         Returns:
+        -------
             OverridesMapping: A dictionary containing the previous overrides that were replaced.
 
         """
-
         with self._overrides_lock:
             old_overrides: OverridesMapping = {}
 
@@ -78,14 +77,17 @@ class DependenciesManager:
         Restores the overridden dependencies to their original values based on the provided overrides and old_overrides mappings.
 
         Args:
+        ----
             overrides (OverridesMapping): A dictionary containing the current overrides for the dependencies.
             old_overrides (OverridesMapping): A dictionary containing the previous overrides for the dependencies.
 
         Returns:
+        -------
             None
+
         """
         with self._overrides_lock:
-            for dep in overrides.keys():
+            for dep in overrides:
                 if dep in old_overrides:
                     self.dependency_overrides[dep] = old_overrides.pop(dep)
                 else:

--- a/pyinject/overrider.py
+++ b/pyinject/overrider.py
@@ -1,21 +1,29 @@
 import typing
 
+from .decorators import AutoWired, P, R
 from .manager import DependenciesManager, OverridesMapping, default_manager
-from .decorators import AutoWired, R, P
 
 
 class DependencyOverrider:
+    """A context manager that overrides the dependencies with the provided overrides."""
+
     def __init__(self, overrides: OverridesMapping, *, manager: DependenciesManager = default_manager) -> None:
         self.overrides = overrides
         self.manager = manager
         self._old_overrides: OverridesMapping = {}
 
-    def __enter__(self):
+    def __enter__(self):  # noqa: ANN204
+        """Overrides the dependencies with the provided overrides."""
         self._old_overrides = self.manager.override_dependencies(self.overrides)
         return self
 
-    def __exit__(self, *args: typing.Any) -> None:
+    def __exit__(self, *args: object) -> None:
+        """Restores the overridden dependencies to their original values."""
         self.manager.restore_dependencies(self.overrides, self._old_overrides)
 
     def execute(self, func: typing.Callable[P, R], *args, **kwargs) -> R:
-        return AutoWired(manager=self.manager)(func)(*args, **kwargs)
+        """Executes a function with the given arguments and keyword arguments.
+
+        Resolving the dependencies from the manager provided in the constructor.
+        """
+        return AutoWired(manager=self.manager)(func)(*args, **kwargs)  # type: ignore reportCallIssue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ python = "^3.10"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
 pytest-cov = "^4.1.0"
-black = "^23.11.0"
 ipython = "^8.18.1"
 mypy = "^1.7.1"
 pytest-xdist = "^3.5.0"
+ruff = "^0.2.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_dependency_overrider.py
+++ b/tests/test_dependency_overrider.py
@@ -20,7 +20,7 @@ def foo_override():
     return 2
 
 
-@pytest.fixture
+@pytest.fixture()
 def manager() -> DependenciesManager:
     return create_manager()
 
@@ -70,3 +70,14 @@ def test_autowired__overriding_manager_overriding_dependency(manager: Dependenci
     """Executing function in isolation with overridden manager"""
     with DependencyOverrider({foo: foo_override}, manager=manager) as overrider:
         assert overrider.execute(func2) == 4
+
+
+def test_autowired__overriding_manager_overriding_dependency_nested() -> None:
+    """Executing function in isolation with overridden manager"""
+
+    @AutoWired()
+    def func_nested(foo: Annotated[int, Depends(foo)], func: Annotated[int, Depends(func)]) -> int:
+        return foo + func
+
+    with DependencyOverrider({foo: foo_override}):
+        assert _(func_nested) == 6


### PR DESCRIPTION
- Added a feature to override dependencies globally without the need for Annotated
- Refactoring of the AutoWired decorator using a utility class
- Switching to Ruff for linting and Formatting.
- Fix and addition of code docs.